### PR TITLE
Moved git package install to repo.pp

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,7 +7,6 @@ class nfsen::install {
   assert_private()
 
   $packages = [
-    'git',
     'libmailtools-perl',
     'librrds-perl',
     'perl',

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -5,6 +5,10 @@
 class nfsen::repo {
 
   if $::nfsen::custom_repo {
+    #git package has to be installed prior to using vcsrepo
+    ensure_packages('git')
+
+    Package['git'] ->
 
     # Installs the repo from a customized source e.g. github
     vcsrepo { '/opt/nfsen':


### PR DESCRIPTION
Using a custom repo failed due to git not being installed yet.
Only installing git if the user is using a custom repo also makes sense.
